### PR TITLE
1.2.2 余計なセーブデータ拡張を排除

### DIFF
--- a/src/codes/ExpandTargetScope/config.yml
+++ b/src/codes/ExpandTargetScope/config.yml
@@ -3,6 +3,9 @@ DarkPlasma_ExpandTargetScope:
   year: 2020
   license: MIT
   histories:
+    - date: 2022/08/16
+      version: 1.2.2
+      description: '余計なセーブデータ拡張を排除'
     - date: 2022/05/09
       version: 1.2.1
       description: '全体化できないスキルが全体化される不具合を修正'


### PR DESCRIPTION
`Game_Battler` にメンバを追加するとアクターのセーブデータに含まれてしまう。
bool値ひとつだけなので大した容量ではないが、 `Game_Temp` に逃がすことでセーブデータに追加せずに済む。